### PR TITLE
Override of inventory_hostname not working

### DIFF
--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -1228,7 +1228,7 @@ class Runner(object):
         # Lookup the python interp from the host or delegate
 
         # host == inven_host when there is no delegate
-        host = inject['inventory_hostname']
+        host = inject['hostvars'].get('inventory_hostname')
         if 'delegate_to' in inject:
             delegate = inject['delegate_to']
             if delegate:


### PR DESCRIPTION
When doing overrides of `inventory_hostname` and `ansible_ssh_host` the `inventory_hostname` overrides stopped working resulting in a 'host not found' error.

Example inventory file:
```ini
[test]
1.2.3.4
```

Example playbook demonstrating problem:
```yaml
---
- hosts: all
  gather_facts: yes

  tasks:
  - set_fact: ansible_ssh_host="{{ ansible_default_ipv4.address }}"
  - set_fact: inventory_hostname="testname"
  - copy: content="test" dest=/tmp/test
```